### PR TITLE
Update node-v8-clone to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "docker-modem": "*",
     "flat-validator": "git://github.com/appersonlabs/flat-validator.git",
-    "node-v8-clone": "~0.4.5"
+    "node-v8-clone": "latest"
   },
   "devDependencies": {
     "chai": "~1.8.0",


### PR DESCRIPTION
Resolves this issue:
npm ERR! Darwin 14.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.5
npm ERR! npm  v2.11.2
npm ERR! code ELIFECYCLE

npm ERR! node-v8-clone@0.4.5 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the node-v8-clone@0.4.5 install script 'node-gyp rebuild'.
npm ERR! This is most likely a problem with the node-v8-clone package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls node-v8-clone
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request: